### PR TITLE
ci: add GitHub templates and conventional commits enforcement

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "type-case": [2, "always", "lower-case"],
+    "type-empty": [2, "never"],
+    "scope-case": [2, "always", "lower-case"],
+    "subject-case": [2, "never", ["sentence-case", "start-case", "pascal-case", "upper-case"]],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "header-max-length": [2, "always", 100],
+    "body-leading-blank": [1, "always"],
+    "body-max-line-length": [2, "always", 100],
+    "footer-leading-blank": [1, "always"],
+    "footer-max-line-length": [2, "always", 100]
+  }
+}

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to FXBG-Closet
+
+Thank you for your interest in contributing to FXBG-Closet! This document provides guidelines for contributing to the project.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork locally
+3. Set up the commit message template (optional but recommended):
+   ```bash
+   git config commit.template .gitmessage
+   ```
+4. Create a new branch for your feature or bug fix
+5. Make your changes following conventional commits
+6. Test your changes thoroughly
+7. Submit a pull request
+
+## Commit Message Guidelines
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) to maintain a clean and readable commit history. This also enables automated versioning and changelog generation.
+
+### Format
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+- `feat`: A new feature
+- `fix`: A bug fix
+- `docs`: Documentation only changes
+- `style`: Changes that do not affect the meaning of the code (formatting, etc.)
+- `refactor`: A code change that neither fixes a bug nor adds a feature
+- `perf`: A code change that improves performance
+- `test`: Adding missing tests or correcting existing tests
+- `build`: Changes that affect the build system or external dependencies
+- `ci`: Changes to our CI configuration files and scripts
+- `chore`: Other changes that don't modify src or test files
+- `revert`: Reverts a previous commit
+
+### Examples
+- `feat: add user profile page`
+- `fix(auth): resolve login validation issue`
+- `docs: update installation instructions`
+- `style: fix indentation in header component`
+- `refactor(database): simplify connection logic`
+
+### Rules
+- Use the imperative mood in the subject line ("add" not "added")
+- Don't end the subject line with a period
+- Keep the subject line under 100 characters
+- Use the body to explain what and why vs. how
+
+## Development Guidelines
+
+### Code Style
+
+- Follow PSR-12 coding standards for PHP
+- Use meaningful variable and function names
+- Add comments for complex logic
+- Keep functions small and focused
+
+### Database
+
+- Always use prepared statements for database queries
+- Follow existing naming conventions
+- Document any schema changes
+
+### Security
+
+- Sanitize all user inputs
+- Use proper authentication and authorization
+- Never commit sensitive information (passwords, API keys, etc.)
+
+### Testing
+
+- Test your changes in multiple browsers if UI-related
+- Verify database operations work correctly
+- Test edge cases and error conditions
+
+## Pull Request Process
+
+1. Update documentation if needed
+2. Ensure your code passes all checks
+3. Fill out the pull request template completely
+4. Request review from maintainers
+5. Address any feedback promptly
+
+## Reporting Issues
+
+- Use the appropriate issue template
+- Provide clear reproduction steps
+- Include relevant screenshots or error messages
+- Be respectful and constructive
+
+## Questions?
+
+Feel free to open an issue for questions about contributing or reach out to the maintainers.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+
+A clear and concise description of what actually happened.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+
+- Browser: [e.g. Chrome, Safari]
+- Version: [e.g. 22]
+- Device: [e.g. iPhone6, Desktop]
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+
+A clear and concise description of what you want to happen.
+
+## Problem Statement
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Proposed Solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives Considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional Context
+
+Add any other context or screenshots about the feature request here.
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Checklist
+
+<!-- Thank you for submitting a pull request to our repo. -->
+
+<!-- If this is your first PR in this repo, please run through the checklist
+below to ensure a smooth review and merge process for your PR. -->
+
+- [ ] You've read the [Contributor Guide](Coming soon).
+- [ ] You've included unit or integration tests for your change, where applicable.
+- [ ] You've included inline docs for your change, where applicable.
+- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
+
+<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->
+
+## Description
+
+{Detail}
+
+Fixes #{issue number}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  php-tests:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        php-versions: ['7.4', '8.0', '8.1']
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql
+        coverage: xdebug
+    
+    - name: Validate composer.json and composer.lock
+      run: |
+        if [ -f composer.json ]; then
+          composer validate --strict
+        else
+          echo "No composer.json found, skipping validation"
+        fi
+    
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+    
+    - name: Install dependencies
+      run: |
+        if [ -f composer.json ]; then
+          composer install --prefer-dist --no-progress
+        else
+          echo "No composer.json found, skipping dependency installation"
+        fi
+    
+    - name: Run PHP syntax check
+      run: find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
+    
+    - name: Run PHPUnit tests
+      run: |
+        if [ -f phpunit.xml ] || [ -f phpunit.xml.dist ]; then
+          ./vendor/bin/phpunit
+        else
+          echo "No PHPUnit configuration found, skipping tests"
+        fi
+
+  code-quality:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.1'
+        extensions: mbstring, xml, ctype, iconv, intl
+    
+    - name: Check for security vulnerabilities
+      run: |
+        if [ -f composer.lock ]; then
+          curl -H "Accept: text/plain" https://security.symfony.com/check_lock -F lock=@composer.lock
+        else
+          echo "No composer.lock found, skipping security check"
+        fi
+    
+    - name: Check file permissions
+      run: |
+        echo "Checking for files with incorrect permissions..."
+        find . -type f -name "*.php" -perm /111 -not -path "./vendor/*" | head -10

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,34 @@
+name: Conventional Commits Validation
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  validate-conventional-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR Title and Commits
+        uses: Namchee/conventional-pr@v0.6.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Validate commit messages
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,39 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  pr-title-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (newline-delimited).
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          disallowScopes: |
+            release
+            wip
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          wip: true
+          validateSingleCommit: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,39 @@
+name: Security Scan
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.1'
+    
+    - name: Scan for hardcoded secrets
+      run: |
+        echo "Scanning for potential secrets..."
+        # Check for common patterns that might indicate secrets
+        grep -r -n -i "password\s*=\s*['\"][^'\"]*['\"]" --include="*.php" . | head -5 || true
+        grep -r -n -i "api_key\s*=\s*['\"][^'\"]*['\"]" --include="*.php" . | head -5 || true
+        grep -r -n -i "secret\s*=\s*['\"][^'\"]*['\"]" --include="*.php" . | head -5 || true
+    
+    - name: Check for SQL injection patterns
+      run: |
+        echo "Checking for potential SQL injection vulnerabilities..."
+        grep -r -n "\$_[A-Z]*\[.*\].*['\"].*SELECT\|UPDATE\|DELETE\|INSERT" --include="*.php" . | head -5 || true
+    
+    - name: Check file permissions
+      run: |
+        echo "Checking file permissions..."
+        find . -type f -perm /o+w -not -path "./.git/*" | head -10 || true

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,33 @@
+# <type>[optional scope]: <description>
+#
+# [optional body]
+#
+# [optional footer(s)]
+
+# --- COMMIT END ---
+# Type can be:
+#    feat     (new feature)
+#    fix      (bug fix)
+#    refactor (refactoring production code)
+#    style    (formatting, missing semi colons, etc; no code change)
+#    docs     (changes to documentation)
+#    test     (adding or refactoring tests; no production code change)
+#    chore    (updating grunt tasks etc; no production code change)
+#    perf     (performance improvements)
+#    build    (changes to build system or dependencies)
+#    ci       (changes to CI configuration)
+#    revert   (reverts a previous commit)
+# --------------------
+# Remember to:
+#   - Use the imperative mood in the subject line
+#   - Do not end the subject line with a period
+#   - Capitalize the subject line and each paragraph
+#   - Use the body to explain what and why vs. how
+#   - Separate subject from body with a blank line
+# --------------------
+# Examples:
+#   feat: add user authentication
+#   fix(auth): resolve login validation issue
+#   docs: update API documentation
+#   style: fix indentation in user service
+#   refactor(database): simplify connection logic

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "fxbg-closet",
+  "version": "1.0.0",
+  "description": "Volunteer management system for FXBG-Closet",
+  "scripts": {
+    "prepare": "husky install",
+    "commitlint": "commitlint --edit"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^17.0.0",
+    "@commitlint/config-conventional": "^17.0.0",
+    "husky": "^8.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
+  }
+}


### PR DESCRIPTION
## Summary: Base ci

- Add PR template with structured checklist and description format
- Add issue templates for bug reports and feature requests
- Add CI workflow for PHP syntax checking and security scanning
- Add conventional commits validation workflow using Namchee/conventional-pr
- Add PR title validation workflow with semantic PR checking
- Add commitlint configuration with standard conventional commit rules
- Add commit message template (.gitmessage) with examples and guidelines
- Update CONTRIBUTING.md with detailed conventional commits documentation
- Add package.json with commitlint and husky dependencies for local development